### PR TITLE
Removing unused cv2 import

### DIFF
--- a/src/diffwaveform/waveforms/IMRPhenomD.py
+++ b/src/diffwaveform/waveforms/IMRPhenomD.py
@@ -1,5 +1,4 @@
 from math import pi
-from cv2 import hconcat
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
I'm not sure what `cv2` is, but `hconcat` isn't used anywhere here as far as I can tell!