### PR TITLE
Fix RNG import bugfix

### DIFF
--- a/src/ripple/typing.py
+++ b/src/ripple/typing.py
@@ -7,5 +7,5 @@ import jax.numpy as jnp
 
 
 # TODO: what type should this be?
-PRNGKeyArray = jax._src.prng.PRNGKeyArray  # type: ignore
+PRNGKeyArray = jax.ringdown.PRNGKeyArray  # type: ignore
 Array = jnp.ndarray

--- a/src/ripple/typing.py
+++ b/src/ripple/typing.py
@@ -7,5 +7,5 @@ import jax.numpy as jnp
 
 
 # TODO: what type should this be?
-PRNGKeyArray = jax.ringdown.PRNGKeyArray  # type: ignore
+PRNGKeyArray = jax.random.PRNGKeyArray  # type: ignore
 Array = jnp.ndarray


### PR DESCRIPTION
I got an error from the offending line in `typing.py` when importing IMRPhenomD. This fixed it (thanks to @kazewong )