### PR TITLE
Fixing benchmark

### DIFF
--- a/test/test_imrphenomd.py
+++ b/test/test_imrphenomd.py
@@ -671,17 +671,17 @@ def benchmark_waveform_call():
 
     start = time.time()
     for i in range(n):
-        m1_kg = theta[0, 0] * lal.MSUN_SI
-        m2_kg = theta[0, 1] * lal.MSUN_SI
+        m1_kg = theta[i, 0] * lal.MSUN_SI
+        m2_kg = theta[i, 1] * lal.MSUN_SI
         hp, hc = lalsim.SimInspiralChooseFDWaveform(
             m1_kg,
             m2_kg,
             0.0,
             0.0,
-            theta[0, 2],
+            theta[i, 2],
             0.0,
             0.0,
-            theta[0, 3],
+            theta[i, 3],
             distance,
             inclination,
             phi_ref,
@@ -708,11 +708,12 @@ def benchmark_waveform_call():
         return IMRPhenomD.gen_IMRPhenomD_polar(fs, theta, f_ref)
 
     print("JIT compiling")
-    _ = waveform(theta_ripple[0])
+    waveform(theta_ripple[0])[0].block_until_ready()
     print("Finished JIT compiling")
 
     start = time.time()
-    hp_ripple, hc_ripple = vmap(waveform)(theta_ripple)
+    for t in theta_ripple:
+        waveform(t)[0].block_until_ready()
     end = time.time()
 
     print("Ripple waveform call takes: %.6f ms" % ((end - start) * 1000 / n))


### PR DESCRIPTION
@tedwards2412 — As I thought, there were some issues with the benchmark code as written. The big one was that the JIT compilation was being included in the runtime which we don't want. I know that you thought you had already compiled it, but when you vmap it compiles again! Also, I'm not convinced that the thing you want to benchmark is the vmapped version of the function (in fact it just stalls out on my computer because I don't have enough RAM). Instead a better comparison is what I've done here and just directly loop over parameter values like we do for lal. ~~Once I do this, I find that ripple is actually somewhat _faster_ than lal (at least on my computer)!~~ (Edit: I lied - not faster! I just had a mistake in my script. But I still think this is the right way to benchmark!) Also we can't forget to include the `block_until_ready` call when benchmarking (see [here](https://jax.readthedocs.io/en/latest/async_dispatch.html) for more info).