### PR TITLE
Solved issues with setup and installing ripple

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.9
 install_requires =
     jax
     jaxlib
-    numpy
+    numpy>=1,<2
 
 [options.package_data]
 * = *.dat

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    name="your_project",
+    name="ripplegw",
     install_requires=[
         "ripplegw",
     ],


### PR DESCRIPTION
I encountered some issues when installing a fresh copy of ripple, probably due to the transition with readthedocs. These should be resolved now. 

The numpy version is pinned to <2 since lalsimulation, which is strictly not required for ripple but handy to have in the same conda environment for cross-checking waveforms, seems to break with numpy v2. 