### PR TITLE
Add aligned-spin conditions to PhenomPv2 angle calculations

### DIFF
--- a/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
+++ b/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
@@ -95,7 +95,7 @@ def convert_spins(
     thetaJ_sf = jnp.arccos(J0z_sf / J0)
 
     no_inplane_J0 = jnp.abs(J0x_sf) < MAX_TOL_ATAN and jnp.abs(J0y_sf) < MAX_TOL_ATAN
-    phiJ_sf = jax.where(
+    phiJ_sf = jnp.where(
         no_inplane_J0,
         jnp.pi / 2.0 - phiRef,  # This is the aligned-spin case
         jnp.arctan2(J0y_sf, J0x_sf),

--- a/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
+++ b/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
@@ -94,7 +94,7 @@ def convert_spins(
 
     thetaJ_sf = jnp.arccos(J0z_sf / J0)
 
-    no_inplane_J0 = jnp.abs(J0x_sf) < MAX_TOL_ATAN and jnp.abs(J0y_sf) < MAX_TOL_ATAN
+    no_inplane_J0 = (jnp.abs(J0x_sf) < MAX_TOL_ATAN) & (jnp.abs(J0y_sf) < MAX_TOL_ATAN)
     phiJ_sf = jnp.where(
         no_inplane_J0,
         jnp.pi / 2.0 - phiRef,  # This is the aligned-spin case
@@ -124,7 +124,7 @@ def convert_spins(
     tmp_x, tmp_y, tmp_z = ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
     tmp_x, tmp_y, tmp_z = ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
 
-    no_inplane_LN = jnp.abs(tmp_x) < MAX_TOL_ATAN and jnp.abs(tmp_y) < MAX_TOL_ATAN
+    no_inplane_LN = (jnp.abs(tmp_x) < MAX_TOL_ATAN) & (jnp.abs(tmp_y) < MAX_TOL_ATAN)
     alpha0 = jnp.where(
         no_inplane_LN,
         jnp.pi,  # This is the aligned-spin case

--- a/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
+++ b/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
@@ -16,6 +16,8 @@ from .IMRPhenomD_utils import (
 from ..typing import Array
 from .IMRPhenomD_QNMdata import QNMData_a, QNMData_fRD, QNMData_fdamp
 
+MAX_TOL_ATAN = 1.0e-15
+
 
 # helper functions for LALtoPhenomP:
 def ROTATEZ(angle, x, y, z):
@@ -92,7 +94,12 @@ def convert_spins(
 
     thetaJ_sf = jnp.arccos(J0z_sf / J0)
 
-    phiJ_sf = jnp.arctan2(J0y_sf, J0x_sf)
+    no_inplane_J0 = jnp.abs(J0x_sf) < MAX_TOL_ATAN and jnp.abs(J0y_sf) < MAX_TOL_ATAN
+    phiJ_sf = jax.where(
+        no_inplane_J0,
+        jnp.pi / 2.0 - phiRef,  # This is the aligned-spin case
+        jnp.arctan2(J0y_sf, J0x_sf),
+    )
 
     phi_aligned = -phiJ_sf
 
@@ -117,7 +124,12 @@ def convert_spins(
     tmp_x, tmp_y, tmp_z = ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
     tmp_x, tmp_y, tmp_z = ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
 
-    alpha0 = jnp.arctan2(tmp_y, tmp_x)
+    no_inplane_LN = jnp.abs(tmp_x) < MAX_TOL_ATAN and jnp.abs(tmp_y) < MAX_TOL_ATAN
+    alpha0 = jnp.where(
+        no_inplane_LN,
+        jnp.pi,  # This is the aligned-spin case
+        jnp.arctan2(tmp_y, tmp_x),
+    )
 
     # Finally we determine thetaJ, by rotating N
     tmp_x, tmp_y, tmp_z = Nx_sf, Ny_sf, Nz_sf


### PR DESCRIPTION
This PR adds back the special treatments for two angles in the aligned-spin case implemented in `LALSimulation` for `PhenomPv2`. 
These changes do not affect the behaviour of `PhenomPv2` in most cases, and only in aligned-spin cases. 

Specifically, they are here in `LALSimulation`:
* `phiJ_sf`: [this line](https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_i_m_r_phenom_p_8c_source.html#l00372), and
* `alpha0`: [this line](https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_i_m_r_phenom_p_8c_source.html#l00410)

This PR also fixes the apparent $\pi / 2$ phase shift mentioned in #35.