### PR TITLE
Fix XAS phase ($3 \phi_c$)

### DIFF
--- a/src/ripplegw/waveforms/IMRPhenomXAS.py
+++ b/src/ripplegw/waveforms/IMRPhenomXAS.py
@@ -1351,12 +1351,13 @@ def _gen_IMRPhenomXAS(
         jax.grad(Phase)((fMs_RD - fMs_damp) / M_s, theta_intrinsic, phase_coeffs) / M_s
     )
     linb = linb - dphi22Ref - 2.0 * PI * (500.0 + psi4tostrain)
+    # The addition π shift comes from Y22
     phifRef = (
         -(Phase(f_ref, theta_intrinsic, phase_coeffs) + linb * (f_ref * M_s) + lina)
         + PI / 4.0
         + PI
     )
-    ext_phase_contrib = 2.0 * PI * f * theta_extrinsic[1] - theta_extrinsic[2]
+    ext_phase_contrib = 2.0 * PI * f * theta_extrinsic[1] + 2 * theta_extrinsic[2]
     Psi = Psi + (linb * fM_s) + lina + phifRef - 2 * PI + ext_phase_contrib
 
     A = Amp(f, theta_intrinsic, amp_coeffs, D=theta_extrinsic[0])


### PR DESCRIPTION
As mentioned in #35 and detailed in this [notebook](https://github.com/GW-JAX-Team/ripple/blob/NRTidalv3-dev/test/test_XAS_phase.ipynb), there is a $3\phi_c$ phase shift between the implementation in `LAL` and here in `ripple`. This PR attempts to fix that.

Specifically, this change will conform with the `phifRef` in `LALSim`, the `2.0*pWF->phi0` on this [line](https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsimulation-v6.2.0/lalsimulation/lib/LALSimIMRPhenomX.c?ref_type=tags#L748). 

This PR does not fix the $\pi$ shift that was mentioned, though, which will be left as a task for later.